### PR TITLE
use KiCad's enviroment variables to refer to art directory

### DIFF
--- a/front_pcb/fp-lib-table
+++ b/front_pcb/fp-lib-table
@@ -1,5 +1,5 @@
 (fp_lib_table
   (lib (name footprints)(type KiCad)(uri "$(KIPRJMOD)\\libs\\footprints.pretty")(options "")(descr ""))
   (lib (name common-footprints)(type KiCad)(uri "$(KIPRJMOD)\\..\\common_libs\\footprints.pretty")(options "")(descr ""))
-  (lib (name art)(type KiCad)(uri C:\Users\Samsung\Documents\KiCad\ZeroPhone-PCBs\art)(options "")(descr ""))
+  (lib (name art)(type KiCad)(uri "$(KIPRJMOD)/../art")(options "")(descr ""))
 )


### PR DESCRIPTION
I can't tell which projects use the art directory, but you'll want this format so that others can contribute and it's not hardcoded to a directory on your PC.