### PR TITLE
Place 2x20 female header on back of PCB

### DIFF
--- a/front_pcb/front_prototype.kicad_pcb
+++ b/front_pcb/front_prototype.kicad_pcb
@@ -3005,6 +3005,11 @@
     (pad 42 thru_hole circle (at -2.54 48.26) (size 1.524 1.524) (drill 1) (layers *.Cu *.Mask))
     (pad 43 thru_hole circle (at -5.08 45.72) (size 1.524 1.524) (drill 1) (layers *.Cu *.Mask))
     (pad 44 thru_hole circle (at -5.08 48.26) (size 1.524 1.524) (drill 1) (layers *.Cu *.Mask))
+    (model Socket_Strips.3dshapes/Socket_Strip_Straight_2x20_Pitch2.54mm.wrl
+      (at (xyz 0.05 -0.95 -0.0629921))
+      (scale (xyz 1 1 1))
+      (rotate (xyz 0 180 90))
+    )
   )
 
   (module common-footprints:keypad_overlay (layer F.Cu) (tedit 58BEB3D0) (tstamp 58820845)


### PR DESCRIPTION
These shifts assume PCB is 1.6mm (0.0629921 inches) thick, which is how KiCad 3D models it.

It may be possible to change the Pi's footprint from being referenced to the front to reference it to the back and then remove the shift on the Z axis and offset on the Y axis. I didn't want to break the layout, so I did not attempt this.
![fitment](https://cloud.githubusercontent.com/assets/1299430/26259445/0ca7f6ac-3c97-11e7-85ff-6ad1b7c95987.png)
![two](https://cloud.githubusercontent.com/assets/1299430/26259446/0e471f9c-3c97-11e7-9816-06684c2419c0.png)

