### PR TITLE
Add colorized model

### DIFF
--- a/back_pcb/back_prototype.kicad_pcb
+++ b/back_pcb/back_prototype.kicad_pcb
@@ -3156,7 +3156,7 @@
     )
     (model ${KIPRJMOD}/libs/raspberry_pi_zero/raspberry_pi_zero.wrl
       (at (xyz -0.398622047 -0.9523622 0.1))
-      (scale (xyz 25.4 25.4 25.4))
+      (scale (xyz 393.7 393.7 393.7))
       (rotate (xyz 0 0 90))
     )
   )


### PR DESCRIPTION
Continuation of #36 

Note that colorized model is 29MB and takes a while to load. I reduced the filesize some and it no longer crashes KiCad when opened.
![back_prototype](https://cloud.githubusercontent.com/assets/1299430/26603872/66319d28-4556-11e7-9108-58c5ba65282f.png)

I also had to adjust the scale since I had to export it from a different program.