### PR TITLE
Add interactive HTML BOM generation script

### DIFF
--- a/interactive-bom/Dockerfile
+++ b/interactive-bom/Dockerfile
@@ -1,0 +1,8 @@
+FROM debian:buster
+MAINTAINER Timothée Floure <timothee.floure@fnux.ch>
+
+RUN apt-get update
+RUN apt-get install -y wget kicad
+
+COPY generate-html-bom.sh /usr/local/bin/
+CMD /usr/local/bin/generate-html-bom.sh

--- a/interactive-bom/README.md
+++ b/interactive-bom/README.md
@@ -1,0 +1,33 @@
+# Interactive BOM generation
+
+We use
+[InteractiveHtmlBom](https://github.com/openscopeproject/InteractiveHtmlBom) to
+generate web-based interactive visualisation of our PCBs. The
+`generate-html-bom.sh` script generates the HTML BOMs for each Zerophone
+revision and outputs it in `/tmp/generate-html-bom`. It depends on
+[Kicad](http://kicad-pcb.org/) 5.0.0 and
+[kicad-python](https://github.com/KiCad/kicad-python). Since it is currently
+a pain to setup on most distributions **[1]**, you can use the environment
+defined in `Dockerfile`:
+
+```
+export IMAGE_NAME=zp-htmlbomgenerator
+export CONTAINER_NAME=$IMAGE_NAME
+
+# Using docker
+docker build -t $IMAGE_NAME .
+docker run -it $IMAGE_NAME
+docker cp $CONTAINER_NAME:/tmp/generated-html-bom.tar.gz .
+
+# Using podman/buildah
+podman build -t $IMAGE_NAME .
+podman run --name $CONTAINER_NAME -it $IMAGE_NAME
+volume=$(podman mount $CONTAINER_NAME)
+cp $volume/tmp/generated-html-bom.tar.gz .
+podman unmount $CONTAINER_NAME
+podman rm $CONTAINER_NAME
+```
+
+**[1]** As of writing (Sept. 2018), it works out-of-the-box on
+[Archlinux](https://www.archlinux.org/packages/community/x86_64/kicad/) and
+[Debian buster](https://packages.debian.org/buster/kicad).

--- a/interactive-bom/generate-html-bom.sh
+++ b/interactive-bom/generate-html-bom.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+set -e
+set -x
+
+HTMLBOM_REPOSITORY="https://github.com/openscopeproject/InteractiveHtmlBom"
+HTMLBOM_RELEASE="v1"
+HTMLBOM_ARCHIVE="InteractiveHtmlBom-$HTMLBOM_RELEASE.tar.gz"
+HTMLBOM_SCRIPT="./InteractiveHtmlBom-1/InteractiveHtmlBom/generate_interactive_bom.py"
+
+PCB_REPOSITORY="https://github.com/ZeroPhone/ZeroPhone-PCBs"
+PCB_REVISIONS="gamma delta delta-b"
+
+# Work in /tmp to keep current directory clean
+cd /tmp
+
+# Fetch InteractiveHtmlBom generator
+wget -O $HTMLBOM_ARCHIVE $HTMLBOM_REPOSITORY/archive/$HTMLBOM_RELEASE.tar.gz
+tar xf $HTMLBOM_ARCHIVE
+
+# Fetch PCB revisions and generate HTML files
+for revision in $PCB_REVISIONS; do
+    revision_dir=generated-html-bom/$revision
+
+    wget -O $revision.tar.gz $PCB_REPOSITORY/archive/$revision.tar.gz
+    tar xf $revision.tar.gz
+
+    for pcb_file in $(find "ZeroPhone-PCBs-$revision" -name "*.kicad_pcb") ; do
+        python2 $HTMLBOM_SCRIPT --nobrowser $pcb_file
+
+        pcb_dir=$(dirname $pcb_file)
+        pcb_name=$(basename $pcb_dir)
+        mkdir -p $revision_dir/$pcb_name
+        cp $pcb_dir/bom/ibom.html $revision_dir/$pcb_name/index.html
+    done
+done
+
+# Archive output for easier handling
+tar cvzf generated-html-bom.tar.gz generated-html-bom


### PR DESCRIPTION
As discussed on IRC yesterday, following [this post on hackaday.io](https://hackaday.com/2018/09/04/interactive-kicad-boms-make-hand-assembly-a-breeze/).


> <CRImier> https://hackaday.com/2018/09/04/interactive-kicad-boms-make-hand-assembly-a-breeze/ - hell yeah! Anybody willing to try this out and document it on the Wiki? Will shout you out and stuff =)
<CRImier> We could probably run it on zerophone.org
[...]
<CRImier> OMG that board viewer is so fucking nice
[...]
<CRImier> SO NICE

Output for Gamma/delta/Delta-B:
  * [generated-html-bom.tar.gz](https://github.com/ZeroPhone/ZeroPhone-PCBs/files/2352445/generated-html-bom.tar.gz)
  * [files.fnux.ch/generated-html-bom/](http://files.fnux.ch/generated-html-bom/)
